### PR TITLE
Make `RepetierClient` clonable

### DIFF
--- a/src/RepetierServerSharpApi/RepetierClient.cs
+++ b/src/RepetierServerSharpApi/RepetierClient.cs
@@ -27,7 +27,7 @@ using ErrorEventArgs = SuperSocket.ClientEngine.ErrorEventArgs;
 
 namespace AndreasReitberger.API.Repetier
 {
-    public partial class RepetierClient : ObservableObject, IDisposable //, IRestApiClient
+    public partial class RepetierClient : ObservableObject, IDisposable, ICloneable //, IRestApiClient
     {
         #region Variables
         RestClient restClient;
@@ -5236,6 +5236,14 @@ namespace AndreasReitberger.API.Repetier
                 StopListening();
                 DisconnectWebSocket();
             }
+        }
+        #endregion
+
+        #region Clone
+
+        public object Clone()
+        {
+            return MemberwiseClone();
         }
         #endregion
     }

--- a/src/RepetierServerSharpApi/RepetierServerSharpApi.csproj
+++ b/src/RepetierServerSharpApi/RepetierServerSharpApi.csproj
@@ -12,7 +12,7 @@
     <PackageTags>Repetier, Server, Pro, API, Rest, Sharp</PackageTags>
     <PackageProjectUrl>https://github.com/AndreasReitberger/RepetierServerSharpApi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/AndreasReitberger/RepetierServerSharpApi</RepositoryUrl>
-    <Version>1.2.8</Version>
+    <Version>1.2.9</Version>
     <LangVersion>10.0</LangVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This commit adds the `IClonable` interface to the `RepetierClient` class to allow the object to be clonable later.

Fixed #25