### PR TITLE
Updated `RestSharp` nuget to latest version

### DIFF
--- a/src/RepetierServerSharpApi/RepetierClient.cs
+++ b/src/RepetierServerSharpApi/RepetierClient.cs
@@ -20,7 +20,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using System.Xml.Serialization;
 using WebSocket4Net;
 using ErrorEventArgs = SuperSocket.ClientEngine.ErrorEventArgs;

--- a/src/RepetierServerSharpApi/RepetierServerSharpApi.csproj
+++ b/src/RepetierServerSharpApi/RepetierServerSharpApi.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RCoreSharp" Version="1.0.9" />
-    <PackageReference Include="RestSharp" Version="108.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="WebSocket4Net" Version="0.15.2" />


### PR DESCRIPTION
Seems that the breaking changes have been a bug and in the latest version no changes were necessary.

Fixed #27