### PR TITLE
Switched to `Dictionary` for `PrinterState` fetching

### DIFF
--- a/src/RepetierServerSharpApi.sln
+++ b/src/RepetierServerSharpApi.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30406.217
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.33711.374
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepetierServerSharpApi", "RepetierServerSharpApi\RepetierServerSharpApi.csproj", "{E9C9645B-C3B7-4727-9524-2870A4A01E5C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepetierServerSharpApiTest", "RepetierServerSharpApiTest\RepetierServerSharpApiTest.csproj", "{141A5CFD-0D86-47B8-908C-718F585A3DAA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocket4Net", "..\..\WebSocket4Net\src\WebSocket4Net\WebSocket4Net.csproj", "{D446ED44-4055-40CE-8FA4-827826A6FB4B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D446ED44-4055-40CE-8FA4-827826A6FB4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D446ED44-4055-40CE-8FA4-827826A6FB4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D446ED44-4055-40CE-8FA4-827826A6FB4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D446ED44-4055-40CE-8FA4-827826A6FB4B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RepetierServerSharpApi/Models/Printer/RepetierPrinterStateRespone.cs
+++ b/src/RepetierServerSharpApi/Models/Printer/RepetierPrinterStateRespone.cs
@@ -4,9 +4,11 @@ using System.Collections.Generic;
 
 namespace AndreasReitberger.API.Repetier.Models
 {
+    [Obsolete("Don't use this anymore")]
     public partial class RepetierPrinterStateRespone : ObservableObject
     {
         #region Properties
+        
         [ObservableProperty]
         [JsonProperty("printer")]
         RepetierPrinterState printer = new();
@@ -14,9 +16,7 @@ namespace AndreasReitberger.API.Repetier.Models
         [ObservableProperty]
         [JsonProperty("printer1")]
         RepetierPrinterState printer1 = new();
-        
-        //[ObservableProperty]
-        //Dictionary<string, RepetierPrinterState> printers = new();
+
         #endregion
 
         #region Overrides

--- a/src/RepetierServerSharpApi/RepetierServerSharpApi.csproj
+++ b/src/RepetierServerSharpApi/RepetierServerSharpApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472;net7</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net7</TargetFrameworks>
     <RootNamespace>AndreasReitberger.API.Repetier</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -25,8 +25,12 @@
     <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="WebSocket4Net" Version="0.15.2" />
+    <!--<PackageReference Include="WebSocket4Net" Version="0.15.2" />-->
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\WebSocket4Net\src\WebSocket4Net\WebSocket4Net.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR switches the method, which fetches the `PrinterStates` to a `Dictionary` return value.

Fixed #33