### PR TITLE
Migrated to new `Core` library

### DIFF
--- a/src/RepetierServerSharpApi.sln
+++ b/src/RepetierServerSharpApi.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\common.props = ..\common.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Print3dServer.Core", "..\..\Print3dServer.Core\src\Print3dServer.Core\Print3dServer.Core.csproj", "{759307D0-A6E3-4C67-B977-D5C86B46DF49}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{759307D0-A6E3-4C67-B977-D5C86B46DF49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{759307D0-A6E3-4C67-B977-D5C86B46DF49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{759307D0-A6E3-4C67-B977-D5C86B46DF49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{759307D0-A6E3-4C67-B977-D5C86B46DF49}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RepetierServerSharpApi.sln
+++ b/src/RepetierServerSharpApi.sln
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\common.props = ..\common.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Print3dServer.Core", "..\..\Print3dServer.Core\src\Print3dServer.Core\Print3dServer.Core.csproj", "{759307D0-A6E3-4C67-B977-D5C86B46DF49}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Print3dServer.Core", "..\..\Print3dServer.Core\src\Print3dServer.Core\Print3dServer.Core.csproj", "{0DDB6C2B-E2C0-45C5-AF6A-DFD1186FF4AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,10 +28,11 @@ Global
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{141A5CFD-0D86-47B8-908C-718F585A3DAA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{759307D0-A6E3-4C67-B977-D5C86B46DF49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{759307D0-A6E3-4C67-B977-D5C86B46DF49}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{759307D0-A6E3-4C67-B977-D5C86B46DF49}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{759307D0-A6E3-4C67-B977-D5C86B46DF49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DDB6C2B-E2C0-45C5-AF6A-DFD1186FF4AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DDB6C2B-E2C0-45C5-AF6A-DFD1186FF4AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DDB6C2B-E2C0-45C5-AF6A-DFD1186FF4AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DDB6C2B-E2C0-45C5-AF6A-DFD1186FF4AA}.Release|Any CPU.Build.0 = Release|Any CPU
+
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RepetierServerSharpApi/Models/Job/RepetierCurrentPrintInfo.cs
+++ b/src/RepetierServerSharpApi/Models/Job/RepetierCurrentPrintInfo.cs
@@ -187,7 +187,8 @@ namespace AndreasReitberger.API.Repetier.Models
         IGcodeMeta? meta;
 
         [ObservableProperty, JsonIgnore]
-        double? remainingPrintTime;
+        [NotifyPropertyChangedFor(nameof(RemainingPrintTimeGeneralized))]
+        double ? remainingPrintTime;
         partial void OnRemainingPrintTimeChanged(double? value)
         {
             if (value is not null)

--- a/src/RepetierServerSharpApi/Models/Job/RepetierJobListItem.cs
+++ b/src/RepetierServerSharpApi/Models/Job/RepetierJobListItem.cs
@@ -17,12 +17,6 @@ namespace AndreasReitberger.API.Repetier.Models
         [property: JsonProperty("analysed")]
         long analysed;
 
-        /*
-        [ObservableProperty, JsonIgnore]
-        [property: JsonProperty("created")]
-        long created;
-        */
-
         [ObservableProperty, JsonIgnore]
         [property: JsonProperty("done")]
         double? done;

--- a/src/RepetierServerSharpApi/Models/Model/RepetierModel.cs
+++ b/src/RepetierServerSharpApi/Models/Model/RepetierModel.cs
@@ -223,7 +223,7 @@ namespace AndreasReitberger.API.Repetier.Models
         #region Interface, unused
 
         [ObservableProperty, JsonIgnore]
-        double modified;
+        double? modified;
 
         [ObservableProperty, JsonIgnore]
         string filePath = string.Empty;

--- a/src/RepetierServerSharpApi/Models/Printer/RepetierPrinter.cs
+++ b/src/RepetierServerSharpApi/Models/Printer/RepetierPrinter.cs
@@ -95,14 +95,14 @@ namespace AndreasReitberger.API.Repetier.Models
 
         [ObservableProperty, JsonIgnore]
         [NotifyPropertyChangedFor(nameof(PrintTimeGeneralized))]
-        [property: JsonProperty("printTime")]
+        //[property: JsonProperty("printTime")]
         double? printTime;
         partial void OnPrintTimeChanged(double? value)
         {
             if (value is not null)
                 PrintTimeGeneralized = TimeBaseConvertHelper.FromDoubleSeconds(value);
-            if (value > 0)
-                RemainingPrintDuration = value * PrintProgress;
+            //if (value > 0)
+            //    RemainingPrintDuration = value * PrintProgress;
         }
 
         [ObservableProperty, JsonIgnore]
@@ -152,11 +152,14 @@ namespace AndreasReitberger.API.Repetier.Models
 
         [ObservableProperty, JsonIgnore]
         [NotifyPropertyChangedFor(nameof(PrintDurationGeneralized))]
+        [property: JsonProperty("printTime")]
         double? printDuration = 0;
         partial void OnPrintDurationChanged(double? value)
         {
             if (value is not null)
                 PrintDurationGeneralized = TimeBaseConvertHelper.FromDoubleSeconds(value);
+            if (value > 0)
+                RemainingPrintDuration = value * PrintProgress;
         }
 
         [ObservableProperty, JsonIgnore]
@@ -206,11 +209,12 @@ namespace AndreasReitberger.API.Repetier.Models
         partial void OnPrintProgressChanged(double? value)
         {
             if (value > 0)
-                RemainingPrintDuration = value * PrintTime;
+                RemainingPrintDuration = value * printDuration;
+                //RemainingPrintDuration = value * PrintTime;
         }
 
         [ObservableProperty, JsonIgnore]
-        [NotifyPropertyChangedFor(nameof(PrintTimeGeneralized))]
+        [NotifyPropertyChangedFor(nameof(RemainingPrintDurationGeneralized))]
         double? remainingPrintDuration = 0;
         partial void OnRemainingPrintDurationChanged(double? value)
         {

--- a/src/RepetierServerSharpApi/RepetierServerSharpApi.csproj
+++ b/src/RepetierServerSharpApi/RepetierServerSharpApi.csproj
@@ -28,4 +28,8 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Print3dServer.Core\src\Print3dServer.Core\Print3dServer.Core.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR migrates the project to use the latest `Core` version of `Print3dServer.Core`.

Fixed #111