### PR TITLE
Improved `Gcode` loading

### DIFF
--- a/src/RepetierServerSharpApi/RepetierClient.HttpClient.cs
+++ b/src/RepetierServerSharpApi/RepetierClient.HttpClient.cs
@@ -1,0 +1,14 @@
+﻿using System.Net.Http;
+
+namespace AndreasReitberger.API.Repetier
+{
+    public partial class RepetierClient
+    {
+        #region Properties
+
+        [ObservableProperty]
+        HttpClient? httpClient;
+
+        #endregion
+    }
+}

--- a/src/RepetierServerSharpApiTest/RepetierServerSharpApiTest.csproj
+++ b/src/RepetierServerSharpApiTest/RepetierServerSharpApiTest.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>12</LangVersion>
 		<IsPackable>false</IsPackable>
 		<UserSecretsId>704a0043-27b2-431d-9835-bad916c45ecd</UserSecretsId>
 	</PropertyGroup>


### PR DESCRIPTION
This PR improves the `Gcode` loading by using one `HttpClient` per session. This reduces the load time of the images.

Fixed #9
Fixed #117